### PR TITLE
Implement probability distributions

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,3 +35,13 @@ This Python-based risk analysis engine evaluates complex risk scenarios using a 
 - **Simulation**: Monte Carlo with NumPy; optional symbolic evaluation
 - **Output**: Distribution of outcomes, expected loss, percentiles
 
+
+## Probability Distributions
+
+The engine uses a flexible distribution system that lets you replace any numeric
+parameter with a probability distribution. Supported distributions include fixed
+values, uniform, triangular, normal, lognormal, exponential, Weibull, gamma,
+beta, Poisson, and discrete custom distributions. Additional types can be added
+easily.
+Each Monte Carlo step samples from these distributions using NumPy and SciPy.
+See `examples/monte_carlo_example.py` for a demonstration.

--- a/examples/monte_carlo_example.py
+++ b/examples/monte_carlo_example.py
@@ -1,0 +1,27 @@
+"""Demonstration of using probability distributions in a Monte Carlo loop."""
+from osrisk import from_spec
+import numpy as np
+
+# Example of using distributions in place of numbers
+params = {
+    "duration": {"type": "weibull", "shape": 1.5, "scale": 10.0},
+    "cost": {"type": "normal", "mean": 1000.0, "std": 100.0},
+    "downtime_factor": {"type": "uniform", "low": 0.8, "high": 1.2},
+}
+
+# Convert parameter specifications to distribution objects
+for key, spec in params.items():
+    params[key] = from_spec(spec)
+
+# Simple Monte Carlo simulation
+N = 1000
+results = []
+
+rng = np.random.default_rng()
+for _ in range(N):
+    duration = params["duration"].sample(rng)
+    cost = params["cost"].sample(rng)
+    downtime_factor = params["downtime_factor"].sample(rng)
+    results.append(duration * cost * downtime_factor)
+
+print(f"Simulated {N} trials. Mean outcome: {np.mean(results):.2f}")

--- a/osrisk/__init__.py
+++ b/osrisk/__init__.py
@@ -1,0 +1,33 @@
+"""OSRisk probability distributions utilities."""
+
+from .probability import (
+    Distribution,
+    FixedValue,
+    NormalDistribution,
+    WeibullDistribution,
+    UniformDistribution,
+    TriangularDistribution,
+    LogNormalDistribution,
+    ExponentialDistribution,
+    GammaDistribution,
+    BetaDistribution,
+    PoissonDistribution,
+    DiscreteDistribution,
+    from_spec,
+)
+
+__all__ = [
+    "Distribution",
+    "FixedValue",
+    "NormalDistribution",
+    "WeibullDistribution",
+    "UniformDistribution",
+    "TriangularDistribution",
+    "LogNormalDistribution",
+    "ExponentialDistribution",
+    "GammaDistribution",
+    "BetaDistribution",
+    "PoissonDistribution",
+    "DiscreteDistribution",
+    "from_spec",
+]

--- a/osrisk/probability.py
+++ b/osrisk/probability.py
@@ -1,0 +1,150 @@
+import numpy as np
+from scipy import stats
+from dataclasses import dataclass
+from typing import Any, Dict, List, Optional
+
+class Distribution:
+    """Base class for a probability distribution."""
+    def sample(self, random_state: Optional[np.random.Generator] = None) -> float:
+        raise NotImplementedError
+
+@dataclass
+class FixedValue(Distribution):
+    value: float
+
+    def sample(self, random_state: Optional[np.random.Generator] = None) -> float:
+        return float(self.value)
+
+@dataclass
+class NormalDistribution(Distribution):
+    mean: float
+    std: float
+
+    def sample(self, random_state: Optional[np.random.Generator] = None) -> float:
+        rng = random_state or np.random.default_rng()
+        return float(rng.normal(self.mean, self.std))
+
+@dataclass
+class WeibullDistribution(Distribution):
+    shape: float
+    scale: float
+
+    def sample(self, random_state: Optional[np.random.Generator] = None) -> float:
+        rng = random_state or np.random.default_rng()
+        return float(stats.weibull_min(c=self.shape, scale=self.scale).rvs(random_state=rng))
+
+
+@dataclass
+class UniformDistribution(Distribution):
+    low: float
+    high: float
+
+    def sample(self, random_state: Optional[np.random.Generator] = None) -> float:
+        rng = random_state or np.random.default_rng()
+        return float(rng.uniform(self.low, self.high))
+
+
+@dataclass
+class TriangularDistribution(Distribution):
+    left: float
+    mode: float
+    right: float
+
+    def sample(self, random_state: Optional[np.random.Generator] = None) -> float:
+        rng = random_state or np.random.default_rng()
+        return float(rng.triangular(self.left, self.mode, self.right))
+
+
+@dataclass
+class LogNormalDistribution(Distribution):
+    mean: float
+    sigma: float
+
+    def sample(self, random_state: Optional[np.random.Generator] = None) -> float:
+        rng = random_state or np.random.default_rng()
+        return float(rng.lognormal(self.mean, self.sigma))
+
+
+@dataclass
+class ExponentialDistribution(Distribution):
+    scale: float
+
+    def sample(self, random_state: Optional[np.random.Generator] = None) -> float:
+        rng = random_state or np.random.default_rng()
+        return float(rng.exponential(self.scale))
+
+
+@dataclass
+class GammaDistribution(Distribution):
+    shape: float
+    scale: float
+
+    def sample(self, random_state: Optional[np.random.Generator] = None) -> float:
+        rng = random_state or np.random.default_rng()
+        return float(rng.gamma(self.shape, self.scale))
+
+
+@dataclass
+class BetaDistribution(Distribution):
+    alpha: float
+    beta: float
+
+    def sample(self, random_state: Optional[np.random.Generator] = None) -> float:
+        rng = random_state or np.random.default_rng()
+        return float(rng.beta(self.alpha, self.beta))
+
+
+@dataclass
+class PoissonDistribution(Distribution):
+    lam: float
+
+    def sample(self, random_state: Optional[np.random.Generator] = None) -> float:
+        rng = random_state or np.random.default_rng()
+        return float(rng.poisson(self.lam))
+
+
+@dataclass
+class DiscreteDistribution(Distribution):
+    values: List[float]
+    probs: List[float]
+
+    def sample(self, random_state: Optional[np.random.Generator] = None) -> float:
+        rng = random_state or np.random.default_rng()
+        return float(rng.choice(self.values, p=self.probs))
+
+
+def from_spec(spec: Any) -> Distribution:
+    """Create a distribution from a specification.
+
+    The spec can be:
+        - a number -> FixedValue
+        - a dict with a 'type' key specifying the distribution
+    """
+    if isinstance(spec, (int, float)):
+        return FixedValue(value=float(spec))
+    if not isinstance(spec, Dict):
+        raise ValueError("Invalid distribution specification: %r" % spec)
+    dtype = spec.get('type')
+    if dtype == 'fixed':
+        return FixedValue(value=float(spec['value']))
+    if dtype == 'uniform':
+        return UniformDistribution(low=spec['low'], high=spec['high'])
+    if dtype == 'triangular':
+        return TriangularDistribution(left=spec['left'], mode=spec['mode'], right=spec['right'])
+    if dtype == 'normal':
+        return NormalDistribution(mean=spec['mean'], std=spec['std'])
+    if dtype == 'lognormal':
+        return LogNormalDistribution(mean=spec['mean'], sigma=spec['sigma'])
+    if dtype == 'exponential':
+        return ExponentialDistribution(scale=spec['scale'])
+    if dtype == 'weibull':
+        return WeibullDistribution(shape=spec['shape'], scale=spec['scale'])
+    if dtype == 'gamma':
+        return GammaDistribution(shape=spec['shape'], scale=spec['scale'])
+    if dtype == 'beta':
+        return BetaDistribution(alpha=spec['alpha'], beta=spec['beta'])
+    if dtype == 'poisson':
+        return PoissonDistribution(lam=spec['lam'])
+    if dtype == 'discrete':
+        return DiscreteDistribution(values=spec['values'], probs=spec['probs'])
+    raise ValueError(f"Unknown distribution type: {dtype}")

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+numpy
+scipy

--- a/tests/test_probability.py
+++ b/tests/test_probability.py
@@ -1,0 +1,31 @@
+import unittest
+from osrisk import from_spec, FixedValue
+
+class TestProbability(unittest.TestCase):
+    def test_fixed_value(self):
+        dist = from_spec(5)
+        self.assertIsInstance(dist, FixedValue)
+        self.assertEqual(dist.sample(), 5.0)
+
+    def test_normal_distribution(self):
+        dist = from_spec({"type": "normal", "mean": 0, "std": 1})
+        val = dist.sample()
+        self.assertIsInstance(val, float)
+
+    def test_weibull_distribution(self):
+        dist = from_spec({"type": "weibull", "shape": 2.0, "scale": 3.0})
+        val = dist.sample()
+        self.assertIsInstance(val, float)
+
+    def test_uniform_distribution(self):
+        dist = from_spec({"type": "uniform", "low": 0.0, "high": 1.0})
+        val = dist.sample()
+        self.assertTrue(0.0 <= val <= 1.0)
+
+    def test_discrete_distribution(self):
+        dist = from_spec({"type": "discrete", "values": [1, 2], "probs": [0.3, 0.7]})
+        val = dist.sample()
+        self.assertIn(val, [1, 2])
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- implement `Distribution` abstractions for fixed values, normal and Weibull
- add helper to build a distribution from a specification
- show Monte Carlo sampling example
- document distribution support in README
- add dependency list and simple unit tests
- expand probability distribution support

## Testing
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68431c9c0414832d965c7a13727c3846